### PR TITLE
✨ Add Trello ticket number prompt

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const getAutoAdd = () => config.get(constants.AUTO_ADD)
 const getEmojiFormat = () => config.get(constants.EMOJI_FORMAT)
 const getSignedCommit = () => config.get(constants.SIGNED_COMMIT)
 const getScopePrompt = () => config.get(constants.SCOPE_PROMPT)
+const getTrelloTicketNumberPrompt = () => config.get(constants.TRELLO_TICKET_NUMBER_PROMPT)
 const setAutoAdd = (autoAdd) => config.set(constants.AUTO_ADD, autoAdd)
 const setEmojiFormat = (emojiFormat) => {
   config.set(constants.EMOJI_FORMAT, emojiFormat)
@@ -17,14 +18,19 @@ const setSignedCommit = (signedCommit) => {
 const setScopePrompt = (scopePrompt) => {
   config.set(constants.SCOPE_PROMPT, scopePrompt)
 }
+const setTrelloTicketNumberPrompt = (trelloTicketNumberPrompt) => {
+  config.set(constants.TRELLO_TICKET_NUMBER_PROMPT, trelloTicketNumberPrompt)
+}
 
 module.exports = {
   getAutoAdd,
   getEmojiFormat,
   getSignedCommit,
   getScopePrompt,
+  getTrelloTicketNumberPrompt,
   setAutoAdd,
   setEmojiFormat,
   setSignedCommit,
-  setScopePrompt
+  setScopePrompt,
+  setTrelloTicketNumberPrompt
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,8 +2,14 @@ const AUTO_ADD = 'autoAdd'
 const CODE = 'code'
 const EMOJI_FORMAT = 'emojiFormat'
 const HOOK_MODE = 'hook'
-const HOOK_FILE_CONTENTS = '#!/bin/sh\n# gitmoji as a commit hook\n' +
-  'exec < /dev/tty\ngitmoji-tarkett --hook $1\n'
+const HOOK_FILE_CONTENTS =
+  '#!/bin/sh\n# gitmoji-trello as a commit hook\n' +
+  'BRANCH_NAME=$(git branch | grep \'*\' | sed \'s/* //\')\n' +
+  'if [ $BRANCH_NAME != \'(no branch)\' ]\n' +
+  'then\n' +
+  '  exec < /dev/tty\n' +
+  '  gitmoji-trello --hook $1\n' +
+  'fi'
 const HOOK_PATH = '/hooks/prepare-commit-msg'
 const HOOK_PERMISSIONS = 0o775
 const SIGNED_COMMIT = 'signedCommit'

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ const HOOK_PERMISSIONS = 0o775
 const SIGNED_COMMIT = 'signedCommit'
 const TITLE_MAX_LENGTH_COUNT = 48
 const SCOPE_PROMPT = 'scopePrompt'
+const TRELLO_TICKET_NUMBER_PROMPT = 'trelloTicketNumberPrompt'
 
 module.exports = {
   AUTO_ADD,
@@ -20,5 +21,6 @@ module.exports = {
   HOOK_PERMISSIONS,
   SIGNED_COMMIT,
   TITLE_MAX_LENGTH_COUNT,
-  SCOPE_PROMPT
+  SCOPE_PROMPT,
+  TRELLO_TICKET_NUMBER_PROMPT
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@ const CODE = 'code'
 const EMOJI_FORMAT = 'emojiFormat'
 const HOOK_MODE = 'hook'
 const HOOK_FILE_CONTENTS = '#!/bin/sh\n# gitmoji as a commit hook\n' +
-  'exec < /dev/tty\ngitmoji --hook $1\n'
+  'exec < /dev/tty\ngitmoji-tarkett --hook $1\n'
 const HOOK_PATH = '/hooks/prepare-commit-msg'
 const HOOK_PERMISSIONS = 0o775
 const SIGNED_COMMIT = 'signedCommit'

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -120,7 +120,7 @@ class GitmojiCli {
   }
 
   _hook (answers) {
-    const title = `${answers.gitmoji} ${answers.scope ? `(${answers.scope}): ` : ''}${answers.title}`
+    const title = `${answers.trelloTicketNumber ? `[${answers.trelloTicketNumber}] ` : ''}${answers.gitmoji} ${answers.scope ? `(${answers.scope}): ` : ''}${answers.title}`
     const reference = (answers.reference) ? `#${answers.reference}` : ''
     const body = `${answers.message} ${reference}`
 

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -22,6 +22,7 @@ class GitmojiCli {
     if (!config.getEmojiFormat()) config.setEmojiFormat(constants.CODE)
     if (config.getSignedCommit() === undefined) config.setSignedCommit(false)
     if (config.getScopePrompt() === undefined) config.setScopePrompt(false)
+    if (config.getTrelloTicketNumberPrompt() === undefined) config.setTrelloTicketNumberPrompt(false)
   }
 
   config () {
@@ -30,6 +31,7 @@ class GitmojiCli {
       config.setEmojiFormat(answers[constants.EMOJI_FORMAT])
       config.setSignedCommit(answers[constants.SIGNED_COMMIT])
       config.setScopePrompt(answers[constants.SCOPE_PROMPT])
+      config.setTrelloTicketNumberPrompt(answers[constants.TRELLO_TICKET_NUMBER_PROMPT])
     })
   }
 

--- a/src/gitmoji.js
+++ b/src/gitmoji.js
@@ -133,7 +133,7 @@ class GitmojiCli {
   }
 
   _commit (answers) {
-    const title = `${answers.gitmoji} ${answers.scope ? `(${answers.scope}): ` : ''}${answers.title}`
+    const title = `${answers.trelloTicketNumber ? `[${answers.trelloTicketNumber}] ` : ''}${answers.gitmoji} ${answers.scope ? `(${answers.scope}): ` : ''}${answers.title}`
     const signed = config.getSignedCommit() ? '-S' : ''
     const body = `${answers.message}`
     const commit = `git commit ${signed} -m "${title}" -m "${body}"`

--- a/src/guard.js
+++ b/src/guard.js
@@ -2,11 +2,17 @@ const chalk = require('chalk')
 
 const errors = {
   scope: chalk.red('Enter a valid scope'),
+  trelloTicketNumber: chalk.red('Enter a valid Trello ticket number'),
   title: chalk.red('Enter a valid commit title'),
   message: chalk.red('Enter a valid commit message')
 }
 
 const scope = (scope) => scope.includes('`') ? errors.scope : true
+
+const trelloTicketNumber = (trelloTicketNumber) =>
+  !/^\+?([1-9]\d*)$/.test(trelloTicketNumber)
+    ? errors.trelloTicketNumber
+    : true
 
 const title = (title) => (!title || title.includes('`')) ? errors.title : true
 
@@ -14,6 +20,7 @@ const message = (message) => message.includes('`') ? errors.message : true
 
 module.exports = {
   scope,
+  trelloTicketNumber,
   title,
   message
 }

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -26,10 +26,16 @@ const config = [
     name: constants.SCOPE_PROMPT,
     message: 'Enable scope prompt',
     type: 'confirm'
+  },
+  {
+    name: constants.TRELLO_TICKET_NUMBER_PROMPT,
+    message: 'Enable Trello ticket number prompt',
+    type: 'confirm'
   }
 ]
 
 const gitmoji = (gitmojis) => {
+  const trelloTickerNumberFromCurrentBranch = utils.getTrelloTicketNumberFromCurrentBranch()
   return [
     {
       name: 'gitmoji',
@@ -48,6 +54,12 @@ const gitmoji = (gitmojis) => {
         )
       }
     },
+    ...(configVault.getTrelloTicketNumberPrompt() !== true ? [] : [{
+      name: 'trelloTicketNumber',
+      message: 'Enter the number of the current Trello ticket',
+      ...(trelloTickerNumberFromCurrentBranch && { default: trelloTickerNumberFromCurrentBranch }),
+      validate: guard.trelloTicketNumber
+    }]),
     ...(configVault.getScopePrompt() !== true ? [] : [{
       name: 'scope',
       message: 'Enter the scope of current changes',

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const execa = require('execa')
 
 const gitmojiApiClient = axios.create({
   baseURL: 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master',
@@ -28,8 +29,16 @@ const inputCountTransformer = (input, maxLength) => {
   return `[${input.length}/${maxLength}]: ${input}`
 }
 
+const getTrelloTicketNumberFromCurrentBranch = () => {
+  const result = execa.sync('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+  const trelloTicketNumberRegex = /\/(\d+)/g
+  const regexMatch = trelloTicketNumberRegex.exec(result.stdout)
+  return regexMatch && regexMatch.length > 1 && regexMatch[1] > 0 && regexMatch[1]
+}
+
 module.exports = {
   findGitmojiCommand,
   gitmojiApiClient,
-  inputCountTransformer
+  inputCountTransformer,
+  getTrelloTicketNumberFromCurrentBranch
 }

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -14,10 +14,12 @@ Object {
   "getEmojiFormat": [Function],
   "getScopePrompt": [Function],
   "getSignedCommit": [Function],
+  "getTrelloTicketNumberPrompt": [Function],
   "setAutoAdd": [Function],
   "setEmojiFormat": [Function],
   "setScopePrompt": [Function],
   "setSignedCommit": [Function],
+  "setTrelloTicketNumberPrompt": [Function],
 }
 `;
 
@@ -37,6 +39,7 @@ gitmoji --hook $1
   "SCOPE_PROMPT": "scopePrompt",
   "SIGNED_COMMIT": "signedCommit",
   "TITLE_MAX_LENGTH_COUNT": 48,
+  "TRELLO_TICKET_NUMBER_PROMPT": "trelloTicketNumberPrompt",
 }
 `;
 
@@ -95,6 +98,11 @@ Array [
     "name": "scopePrompt",
     "type": "confirm",
   },
+  Object {
+    "message": "Enable Trello ticket number prompt",
+    "name": "trelloTicketNumberPrompt",
+    "type": "confirm",
+  },
 ]
 `;
 
@@ -105,6 +113,11 @@ Array [
     "name": "gitmoji",
     "source": [Function],
     "type": "autocomplete",
+  },
+  Object {
+    "message": "Enter the number of the current Trello ticket",
+    "name": "trelloTicketNumber",
+    "validate": [Function],
   },
   Object {
     "message": "Enter the commit title",

--- a/test/__snapshots__/gitmojiCli.spec.js.snap
+++ b/test/__snapshots__/gitmojiCli.spec.js.snap
@@ -29,10 +29,13 @@ Object {
   "CODE": "code",
   "EMOJI_FORMAT": "emojiFormat",
   "HOOK_FILE_CONTENTS": "#!/bin/sh
-# gitmoji as a commit hook
-exec < /dev/tty
-gitmoji --hook $1
-",
+# gitmoji-trello as a commit hook
+BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
+if [ $BRANCH_NAME != '(no branch)' ]
+then
+  exec < /dev/tty
+  gitmoji-trello --hook $1
+fi",
   "HOOK_MODE": "hook",
   "HOOK_PATH": "/hooks/prepare-commit-msg",
   "HOOK_PERMISSIONS": 509,


### PR DESCRIPTION
## Description

This pull requests add a config prompt that allows users to add a Trello ticket number prompt when they commit.
![image](https://user-images.githubusercontent.com/19605940/68026424-fb790700-fcaf-11e9-8449-10d89a766494.png)

If enabled, the user can enter a Trello ticket number that would be displayed in square brackets before the emoji, like so:
![image](https://user-images.githubusercontent.com/19605940/68026530-4dba2800-fcb0-11e9-8f1a-9dd17d97ffb7.png)

If the current git branch name contains a Trello ticket number (ie: the name format is like `s${sprintNumber}/${teamName}/${trelloTicketNumber}`, ex `s32/pulsar/123`), the prompt will have the number as default value.
![image](https://user-images.githubusercontent.com/19605940/68026768-ec468900-fcb0-11e9-8c22-aa421c230ed9.png)

This has been developed to try and automate the process of adding the ticket number to commits.


## What remains to be done

- [ ] Move `getTrelloTicketNumberFromCurrentBranch` to `gitmoji.js` to add `this._isAGitRepo()` test before trying to get the git branch
- [ ] Add tests